### PR TITLE
Fix README datasource driver name

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,13 +78,13 @@ Authorization: Bearer <token>
 
 ```properties
 spring.datasource.url=jdbc:h2:mem:testdb
-spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.driver-class-name=org.h2.Driver
 spring.datasource.username=sa
 spring.datasource.password=
 spring.h2.console.enabled=true
 spring.jpa.hibernate.ddl-auto=update
 
-jwt.secret=UnaChiaveSuperSegreta
+jwt.secret=UnaChiaveMoltoSegretaDaUsareInProduzione
 jwt.expiration=86400000
 ```
 


### PR DESCRIPTION
## Summary
- update JDBC driver property to the hyphenated form
- align JWT secret example with `application.properties`

## Testing
- `./mvnw -q test` *(fails: Failed to fetch https://repo.maven.apache.org/maven2/... due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6856b8153af08320bf5a6c26e271d7eb